### PR TITLE
Add subtitle mask layout utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# Subtitle Tool for Adobe Premiere
+
+Utilities for building subtitle masks with predictable alignment and spacing.
+
+The first module in this repository focuses on the layout problem from issue #2:
+subtitle masks should stay centered, respect video bounds, and keep readable
+spacing between words even when word widths vary.
+
+## Mask layout
+
+`src/maskLayout.js` exports `computeMaskLayout(words, options)`.
+
+It accepts measured words:
+
+```js
+const words = [
+  { text: "hello", width: 92 },
+  { text: "world", width: 110 }
+];
+```
+
+and returns mask rectangles with `x`, `y`, `width`, and `height` values that can
+be mapped into a Premiere/ExtendScript overlay layer later.
+
+```js
+import { computeMaskLayout } from "./src/maskLayout.js";
+
+const layout = computeMaskLayout(words, {
+  frameWidth: 1920,
+  frameHeight: 1080,
+  y: 900,
+  maskHeight: 72
+});
+```
+
+The layout engine supports:
+
+- fixed or word-relative horizontal padding
+- centered line alignment
+- bounded positioning inside the video frame
+- stable gap handling for variable-width words
+
+## Development
+
+```bash
+npm install
+npm test
+```
+
+The tests use Node's built-in `node:test` runner and do not require Adobe
+Premiere.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "subtitle-tool-for-adobe-premiere",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/src/maskLayout.js
+++ b/src/maskLayout.js
@@ -1,0 +1,79 @@
+const DEFAULTS = {
+  frameWidth: 1920,
+  frameHeight: 1080,
+  y: 880,
+  maskHeight: 68,
+  minPaddingX: 18,
+  relativePadding: 0.12,
+  wordGap: 10
+};
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function normalizeWords(words) {
+  if (!Array.isArray(words) || words.length === 0) {
+    throw new Error("words must be a non-empty array");
+  }
+
+  return words.map((word, index) => {
+    const width = Number(word.width);
+
+    if (!Number.isFinite(width) || width <= 0) {
+      throw new Error(`word at index ${index} must include a positive width`);
+    }
+
+    return {
+      text: String(word.text ?? ""),
+      width
+    };
+  });
+}
+
+export function computeMaskLayout(words, options = {}) {
+  const normalizedWords = normalizeWords(words);
+  const settings = { ...DEFAULTS, ...options };
+
+  if (settings.frameWidth <= 0 || settings.frameHeight <= 0) {
+    throw new Error("frame dimensions must be positive");
+  }
+
+  const masks = normalizedWords.map((word) => {
+    const paddingX = Math.max(
+      settings.minPaddingX,
+      Math.round(word.width * settings.relativePadding)
+    );
+
+    return {
+      text: word.text,
+      width: word.width + paddingX * 2,
+      height: settings.maskHeight
+    };
+  });
+
+  const totalWidth =
+    masks.reduce((sum, mask) => sum + mask.width, 0) +
+    settings.wordGap * (masks.length - 1);
+  const boundedTotalWidth = Math.min(totalWidth, settings.frameWidth);
+  let cursorX = Math.round((settings.frameWidth - boundedTotalWidth) / 2);
+  const y = clamp(
+    settings.y,
+    0,
+    Math.max(0, settings.frameHeight - settings.maskHeight)
+  );
+
+  return masks.map((mask) => {
+    const width = Math.min(mask.width, settings.frameWidth);
+    const x = clamp(cursorX, 0, Math.max(0, settings.frameWidth - width));
+    cursorX = x + width + settings.wordGap;
+
+    return {
+      text: mask.text,
+      x,
+      y,
+      width,
+      height: mask.height
+    };
+  });
+}

--- a/test/maskLayout.test.js
+++ b/test/maskLayout.test.js
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { computeMaskLayout } from "../src/maskLayout.js";
+
+test("centers masks as one line", () => {
+  const layout = computeMaskLayout(
+    [
+      { text: "one", width: 50 },
+      { text: "two", width: 70 }
+    ],
+    {
+      frameWidth: 300,
+      frameHeight: 200,
+      y: 150,
+      maskHeight: 40,
+      minPaddingX: 10,
+      relativePadding: 0,
+      wordGap: 10
+    }
+  );
+
+  assert.deepEqual(layout, [
+    { text: "one", x: 65, y: 150, width: 70, height: 40 },
+    { text: "two", x: 145, y: 150, width: 90, height: 40 }
+  ]);
+});
+
+test("keeps masks inside frame bounds", () => {
+  const layout = computeMaskLayout([{ text: "long", width: 500 }], {
+    frameWidth: 320,
+    frameHeight: 180,
+    y: 999,
+    maskHeight: 50
+  });
+
+  assert.equal(layout[0].x, 0);
+  assert.equal(layout[0].y, 130);
+  assert.equal(layout[0].width, 320);
+});
+
+test("rejects missing word measurements", () => {
+  assert.throws(
+    () => computeMaskLayout([{ text: "missing width" }]),
+    /positive width/
+  );
+});


### PR DESCRIPTION
## Summary
- add a small mask layout engine for centered subtitle masks
- keep computed masks inside the video frame and support variable word widths
- include Node test coverage and setup notes

## Testing
- npm test

Closes #2